### PR TITLE
[Draw & Distance apps] Add them as functional Scarpet Rules

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -352,7 +352,8 @@ public class CarpetSettings
     @Rule(
             desc = "Enables /distance command to measure in game distance between points",
             extra = "Also enables brown carpet placement action if 'carpets' rule is turned on as well",
-            category = COMMAND
+            //appSource = "distance",
+            category = {COMMAND,SCARPET}
     )
     public static String commandDistance = "true";
 
@@ -378,7 +379,7 @@ public class CarpetSettings
             extra = {"... allows for drawing simple shapes or",
                      "other shapes which are sorta difficult to do normally"},
             appSource = "draw",
-            category = COMMAND, SCARPET)
+            category = {COMMAND, SCARPET})
     public static String commandDraw = "true";
 
     @Rule(

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -99,25 +99,6 @@ public class CarpetSettings
     )
     public static boolean commandAITracker = true;
 
-    @Rule(
-        desc = "Enables /draw commands",
-        extra = {
-            "... allows for drawing simple shapes or",
-            "other shapes which are sorta difficult to do normally"
-        },
-        appSource = "draw",
-        category = {FEATURE, SCARPET, COMMAND}
-    )
-    public static boolean commandDraw = false;
-
-    @Rule(
-        desc = "Enables /distance command to measure in game distance between points",
-        extra = "Also enables brown carpet placement action if 'carpets' rule is turned on as well",
-        appSource = "distance",
-        category = {FEATURE, SCARPET, COMMAND}
-    )
-    public static boolean commandDistance = false;
-
     */
 
 
@@ -392,7 +373,12 @@ public class CarpetSettings
     )
     public static String commandPerimeterInfo = "true";
 
-    @Rule(desc = "Enables /draw commands", extra = {"... allows for drawing simple shapes or","other shapes which are sorta difficult to do normally"}, category = COMMAND)
+    @Rule(
+            desc = "Enables /draw commands", 
+            extra = {"... allows for drawing simple shapes or",
+                     "other shapes which are sorta difficult to do normally"},
+            appSource = "draw",
+            category = COMMAND, SCARPET)
     public static String commandDraw = "true";
 
     @Rule(

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -75,8 +75,8 @@ public class CarpetScriptServer
         registerBuiltInScript(BundledModule.carpetNative("math", true));
         registerBuiltInScript(BundledModule.carpetNative("chunk_display", false));
         registerBuiltInScript(BundledModule.carpetNative("ai_tracker", false));
-        registerBuiltInScript(BundledModule.carpetNative("draw", false));
-        //registerBuiltInScript(BundledModule.carpetNative("distance", false));
+        registerSettingsApp(BundledModule.carpetNative("draw", false));
+        //registerSettingsApp(BundledModule.carpetNative("distance", false));
     }
 
     public CarpetScriptServer(MinecraftServer server)


### PR DESCRIPTION
Scarpet Rules implementation is fully functional since it was merged, the reason those apps weren't added were (I think) is because they use some events only part of the time (that could benefit of the new unhandling) and they used the old command system, that was already being reworked.

Since yours already use it, they can be added already. This PR registers them to the correct pool and assigns them to their old rules (only draw yet, but distance is prepared, since it doesn't exist yet).

Also they can be strings, like the old commands, to prevent compatibility issues. If you want you can also add a perm check with the current tech or wait for gnembon#542.

BTW draw is looking good, I've already filled a test world.

A suggestion: The hollow thing, make it so instead of true/false, which can be difficult to understand if brigadier doesn't tell you what that is (and only says true/false), be a string either `hollow` or whatever the best for the opposite is (filled? idk).

Also can't draw be global? Since it doesn't really save any per-player info, so it only exists once.