### PR TITLE
[Draw and Distance Apps] Make the rule apps work

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -108,7 +108,7 @@ public class CarpetSettings
         appSource = "draw",
         category = {FEATURE, SCARPET, COMMAND}
     )
-    public static boolean commandDraw = false;
+    public static String commandDraw = "true";
 
     @Rule(
         desc = "Enables /distance command to measure in game distance between points",
@@ -116,7 +116,7 @@ public class CarpetSettings
         appSource = "distance",
         category = {FEATURE, SCARPET, COMMAND}
     )
-    public static boolean commandDistance = false;
+    public static String commandDistance = "true";
 
 
 

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -75,8 +75,8 @@ public class CarpetScriptServer
         registerBuiltInScript(BundledModule.carpetNative("math", true));
         registerBuiltInScript(BundledModule.carpetNative("chunk_display", false));
         registerBuiltInScript(BundledModule.carpetNative("ai_tracker", false));
-        registerBuiltInScript(BundledModule.carpetNative("draw", false));
-        registerBuiltInScript(BundledModule.carpetNative("distance", false));
+        registerSettingsApp(BundledModule.carpetNative("draw", false));
+        registerSettingsApp(BundledModule.carpetNative("distance", false));
     }
 
     public CarpetScriptServer(MinecraftServer server)


### PR DESCRIPTION
This PR registers the apps to the correct pool.

Also this changes them to strings (since they are supported), like the old commands, to prevent compatibility issues and in preparation to command perms. If you want you can also add a perm check with the current tech or wait for gnembon#542.

Superseeds #17.

_Note: Unlike #17, I haven't tested this specific PR, but it should work (at least it compiles)_