### PR TITLE
[Replace Commands Branch] Optimize draw_sphere

### DIFF
--- a/src/main/resources/assets/carpet/scripts/draw_rc_1.sc
+++ b/src/main/resources/assets/carpet/scripts/draw_rc_1.sc
@@ -51,7 +51,7 @@ affected(player) -> (
     affected
 );
 
-length_sq(vec)->return(_vec_length(vec)^2);//cos of lengthSq func in DrawCommand.java
+length_sq(vec) -> _vec_length(vec)^2; //cos of lengthSq func in DrawCommand.java
 
 fill_flat(pos, offset, dr, rectangle, orientation, block, hollow, replacement)->(
     r = floor(dr);

--- a/src/main/resources/assets/carpet/scripts/draw_rc_1.sc
+++ b/src/main/resources/assets/carpet/scripts/draw_rc_1.sc
@@ -115,16 +115,18 @@ draw_sphere(pos, radius, block, replacement, hollow)->(
             nextZn = 0;
             instaquit = false;
             c_for(z=0,z<=ceilRadiusZ,z+=1,
-                zn = nextZn;
-                nextZn = (z+1)/radiusZ;
+                if(!instaquit,
+                    zn = nextZn;
+                    nextZn = (z+1)/radiusZ;
 
-                if(!instaquit && length_sq([xn, yn, zn]) > 1,instaquit = true);
+                    if(length_sq([xn, yn, zn]) > 1,instaquit = true);
 
-                if (!instaquit && !(!hollow && length_sq([nextXn, yn, zn]) <= 1 && length_sq([xn, nextYn, zn]) <= 1 && length_sq([xn, yn, nextZn]) <= 1),
-                    c_for(xmod=-1,xmod<2,xmod+=2,
-                        c_for(ymod=-1,ymod<2,ymod+=2,
-                            c_for(zmod=-1,zmod<2,zmod+=2,
-                                set_block(pos:0 + xmod*x, pos:1 + ymod*y, pos:2 + zmod*z, block, replacement)
+                    if(!(!hollow && length_sq([nextXn, yn, zn]) <= 1 && length_sq([xn, nextYn, zn]) <= 1 && length_sq([xn, yn, nextZn]) <= 1),
+                        c_for(xmod=-1,xmod<2,xmod+=2,
+                            c_for(ymod=-1,ymod<2,ymod+=2,
+                                c_for(zmod=-1,zmod<2,zmod+=2,
+                                    set_block(pos:0 + xmod*x, pos:1 + ymod*y, pos:2 + zmod*z, block, replacement)
+                                )
                             )
                         )
                     )

--- a/src/main/resources/assets/carpet/scripts/math.scl
+++ b/src/main/resources/assets/carpet/scripts/math.scl
@@ -2,4 +2,4 @@ _euclidean_sq(vec1, vec2) -> reduce(vec1 - vec2, _a + _*_, 0);
 _euclidean(vec1, vec2) -> sqrt(reduce(vec1 - vec2, _a + _*_, 0));
 _manhattan(vec1, vec2) -> reduce(vec1-vec2,_a+abs(_),0);
 _vec_length(vec) -> sqrt(reduce(vec, _a + _*_, 0));
-_round(num,precision)->return(round(num*precision)/precision);
+_round(num,precision) -> round(num*precision)/precision;


### PR DESCRIPTION
This PR is for the branch of gnembon#553. It:

- Optimizes `draw_sphere` so instead of relying on the extremely expensive `break()` and `continue()`, it is just whether to continue in an if
   - For continue, the code is just not executed (instead of `if invalid continue()`, it does `if valid do`)
   - For break, a variable (`instaquit`) is initialized outside the loop. If the break condition is met, `instaquit = true`. If it is true, code is just skipped.
    - For return, since functions return by default whatever there is at the end of them, it just places it at the end without the return call (because it is also quite expensive)
- Moves common usages to a function
   - Basically every function calls a print to tell affected blocks, so let's make one for that (`affected(player)`)
   - Tracking affected blocks is now done via a global instead, that is updated from `set_block`, so it doesn't need to be calculated and reseted everywhere
   - Still "returns" the count of affected blocks by creating `affected` there: nano-optimization to say the most

Also removes the check to carpet rule (as discussed in a comment) since it's not needed and just double-updates and adds some overhead (since `carpet_rules` is also quite expensive and is ran for every block).